### PR TITLE
Support mariadb and parallel restore

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -49,7 +49,8 @@ class xtrabackup (
   $slaveinfo = undef,             # Record master log pos if true
   $scriptdir = '/usr/local/bin/', # The default script dir
   $p_threads = 10,                # Pigz threads to use
-  $version   = 'present'
+  $version   = 'present',
+  $compat    = undef              # Set to 'maria' to work with mariabackup
 ) {
   class{'xtrabackup::install': } ->
   class{'xtrabackup::config': } ->

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -50,7 +50,7 @@ class xtrabackup (
   $scriptdir = '/usr/local/bin/', # The default script dir
   $p_threads = 10,                # Pigz threads to use
   $version   = 'present',
-  $compat    = undef              # Set to 'maria' to work with mariabackup
+  $compatibility_version = undef  # Set to 'mariadb' to work with mariabackup
 ) {
   class{'xtrabackup::install': } ->
   class{'xtrabackup::config': } ->

--- a/templates/backupscript.sh.erb
+++ b/templates/backupscript.sh.erb
@@ -37,7 +37,7 @@ OUTFILE="<%= scope.lookupvar('::xtrabackup::outputdir') %>/${database_name}/xtra
 
 <% if scope.lookupvar('::xtrabackup::compat') == 'maria' -%>
 /usr/bin/mariabackup --innobackupex $OPTS | nice pigz -p <%= scope.lookupvar('::xtrabackup::p_threads') -%> > $OUTFILE
-<% else %>
+<% else -%>
 /usr/bin/innobackupex $OPTS | nice pigz -p <%= scope.lookupvar('::xtrabackup::p_threads') -%> > $OUTFILE
 <% end -%>
 touch $OUTFILE.success

--- a/templates/backupscript.sh.erb
+++ b/templates/backupscript.sh.erb
@@ -35,7 +35,7 @@ OPTS="$OPTS <%= scope.lookupvar('::xtrabackup::workdir') %>"
 
 OUTFILE="<%= scope.lookupvar('::xtrabackup::outputdir') %>/${database_name}/xtrabackup/${DATE}.${database_name}.xbstream.gz"
 
-<% if scope.lookupvar('::xtrabackup::compat') == 'maria' -%>
+<% if scope.lookupvar('::xtrabackup::compatibility_version') == 'mariadb' -%>
 /usr/bin/mariabackup --innobackupex $OPTS | nice pigz -p <%= scope.lookupvar('::xtrabackup::p_threads') -%> > $OUTFILE
 <% else -%>
 /usr/bin/innobackupex $OPTS | nice pigz -p <%= scope.lookupvar('::xtrabackup::p_threads') -%> > $OUTFILE

--- a/templates/backupscript.sh.erb
+++ b/templates/backupscript.sh.erb
@@ -32,6 +32,12 @@ OPTS="$OPTS <%= scope.lookupvar('::xtrabackup::workdir') %>"
 <% if scope.lookupvar('::xtrabackup::slaveinfo') -%>
   OPTS="$OPTS --slave-info"
 <% end -%>
+
 OUTFILE="<%= scope.lookupvar('::xtrabackup::outputdir') %>/${database_name}/xtrabackup/${DATE}.${database_name}.xbstream.gz"
+
+<% if scope.lookupvar('::xtrabackup::compat') == 'maria' -%>
+/usr/bin/mariabackup --innobackupex $OPTS | nice pigz -p <%= scope.lookupvar('::xtrabackup::p_threads') -%> > $OUTFILE
+<% else %>
 /usr/bin/innobackupex $OPTS | nice pigz -p <%= scope.lookupvar('::xtrabackup::p_threads') -%> > $OUTFILE
+<% end -%>
 touch $OUTFILE.success

--- a/templates/restorescript.sh.erb
+++ b/templates/restorescript.sh.erb
@@ -2,25 +2,33 @@
 
 XBSTREAM=$1
 DESTDIR=$2
+CPUCORE_COUNT=$(nproc --all)
+# Assume we want to restore ASAP so use all the cores.
+# Set env var if you feel differently
+PARALLEL="${PARALLEL:-$CPUCORE_COUNT}"
 
-if [ x${XBSTREAM} == "x" ] || [ x${DESTDIR} == "x" ]; then
+if [ "x${XBSTREAM}" == "x" ] || [ "x${DESTDIR}" == "x" ]; then
   echo "Usage: $0 <xbstream backup> <destination directory>"
   exit 1
 fi
 
-if [ ! -f $XBSTREAM ]; then
+if [ ! -f "${XBSTREAM}" ]; then
   echo "Can't find backup $XBSTREAM"
   exit 1
 fi
-if [ -d $DESTDIR ]; then
+if [ -d "${DESTDIR}" ]; then
   echo "Destination $DESTDIR already exists; will not overwrite"
   exit 1
 fi
 
-mkdir -p $DESTDIR/data $DESTDIR/master_log $DESTDIR/relay_log $DESTDIR/log $DESTDIR/tmp
+mkdir -p "${DESTDIR}/data" "${DESTDIR}/master_log" "${DESTDIR}/relay_log" "${DESTDIR}/log" "${DESTDIR}/tmp"
 
-pigz -cd $XBSTREAM |
-xbstream -x -C $DESTDIR/data
-innobackupex --apply-log $DESTDIR/data
-touch $DESTDIR/log/err.log
-chown -R mysql:mysql $DESTDIR
+pigz -p "${PARALLEL}" -cd "${XBSTREAM}" |
+xbstream -x -C "${DESTDIR}/data"
+<% if scope.lookupvar('::xtrabackup::compat') == 'maria' -%>
+/usr/bin/mariabackup --innobackupex --apply-log "${DESTDIR}/data"
+<% else %>
+/usr/bin/innobackupex --apply-log "${DESTDIR}/data"
+<% end -%>
+touch "${DESTDIR}/log/err.log"
+chown -R mysql:mysql "${DESTDIR}"

--- a/templates/restorescript.sh.erb
+++ b/templates/restorescript.sh.erb
@@ -25,7 +25,7 @@ mkdir -p "${DESTDIR}/data" "${DESTDIR}/master_log" "${DESTDIR}/relay_log" "${DES
 
 pigz -p "${PARALLEL}" -cd "${XBSTREAM}" |
 xbstream -x -C "${DESTDIR}/data"
-<% if scope.lookupvar('::xtrabackup::compat') == 'maria' -%>
+<% if scope.lookupvar('::xtrabackup::compatibility_version') == 'mariadb' -%>
 /usr/bin/mariabackup --innobackupex --apply-log "${DESTDIR}/data"
 <% else -%>
 /usr/bin/innobackupex --apply-log "${DESTDIR}/data"

--- a/templates/restorescript.sh.erb
+++ b/templates/restorescript.sh.erb
@@ -27,7 +27,7 @@ pigz -p "${PARALLEL}" -cd "${XBSTREAM}" |
 xbstream -x -C "${DESTDIR}/data"
 <% if scope.lookupvar('::xtrabackup::compat') == 'maria' -%>
 /usr/bin/mariabackup --innobackupex --apply-log "${DESTDIR}/data"
-<% else %>
+<% else -%>
 /usr/bin/innobackupex --apply-log "${DESTDIR}/data"
 <% end -%>
 touch "${DESTDIR}/log/err.log"


### PR DESCRIPTION
Added support for mariadb via mariabackup in the backup and restore scripts. The only commands that needed to change were the ones involving innobackupex which is supported in mariabackup by the --innobackupex flag. 

Kept the innobackupex commands as close to what we already have as possible so it's easier to reason about this in the future.

Also added parallelization to the restore script so it can be SUPER FAST.

Relevant ticket: DREIMP-1706